### PR TITLE
Fixed issue regarding reloading at the begining of a VOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Mpv reads its configuration from `MPV_HOME` directory. On Unix it is
 the manual for the Windows configuration files.
 
 To install the script, copy `reload.lua` to the `MPV_HOME/scripts` directory.
-To override default settings, create `reload.conf` file in the lua-settings
-directory `MPV_HOME/lua-settings`.
+To override default settings, create `reload.conf` file in the script-opts
+directory `MPV_HOME/script-opts`.
 
 NOTE: config file name should match the name of the script.
 

--- a/reload.lua
+++ b/reload.lua
@@ -8,7 +8,7 @@
 --
 -- SETTINGS
 --
--- To override default setting put `lua-settings/reload.conf` file in
+-- To override default setting put `script-opts/reload.conf` file in
 -- mpv user folder, on linux it is `~/.config/mpv`.  NOTE: config file
 -- name should match the name of the script.
 --
@@ -318,6 +318,13 @@ function reload_resume()
   if reload_duration and reload_duration > 0 then
     msg.info("reloading video from", time_pos, "second")
     reload(path, time_pos)
+  -- VODs get stuck when reload is called without a time_pos
+  -- this is most noticeable in youtube videos whenever download gets stuck in the first frames
+  -- video would stay paused without being actually paused
+  -- issue surfaced in mpv 0.33, afaik
+  elseif reload_duration and reload_duration == 0 then
+    msg.info("reloading video from", time_pos, "second")
+    reload(path, time_pos)
   else
     msg.info("reloading stream")
     reload(path, nil)
@@ -392,4 +399,4 @@ if settings.reload_eof_enabled then
   mp.observe_property("eof-reached", "bool", reload_eof)
 end
 
---mp.register_event("file-loaded", debug_info)
+--mp.register_event("file-loaded", debug_info) 


### PR DESCRIPTION
Whenever a VOD has to be reloaded at its begining, the script would call `reload(path, nil)`, which causes mpv to get stuck in the first frame of the video thinking it is playing it. 

This patch allows the script to pass the current position to the `reload` when `reload_duration == 0`, fixing the playback getting stuck.

Readme has also been updated as the `lua-settings` directory has been discontinued in favour of `script-opts`.