### PR TITLE
Resume playback after the reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,7 @@ reload_key_binding=Ctrl+r
 ## Debugging
 
 Debug messages will be printed to stdout with mpv command line option
-`--msg-level='reload=debug'`
+`--msg-level='reload=debug'`. You may also need to add the `--no-msg-color`
+option to make the debug logs visible if you are using a dark colorscheme in
+terminal.
+

--- a/reload.lua
+++ b/reload.lua
@@ -408,12 +408,12 @@ function on_file_loaded(event)
 
   -- When the video is reloaded after being paused for cache, it won't start
   -- playing again while all properties looks fine:
-  -- 'pause=no', 'paused-for-cache=no' and 'cache-buffering-state=100'.
+  -- `pause=no`, `paused-for-cache=no` and `cache-buffering-state=100`.
   -- As a workaround, we cycle through the paused state by sending two SPACE
   -- keypresses.
   -- What didn't work:
-  -- - Cycling through the 'pause' property.
-  -- - Run the 'playlist-play-index current' command.
+  -- - Cycling through the `pause` property.
+  -- - Run the `playlist-play-index current` command.
   mp.commandv("keypress", 'SPACE')
   mp.commandv("keypress", 'SPACE')
 end


### PR DESCRIPTION
related: #10 

When the video gets stuck and paused for cache (property `paused-for-cache=yes`), reloading with the `loadfile` command does not trigger the playback anymore. All the video properties looks fine:  `pause=no`, `paused-for-cache=no` and `cache-buffering-state=100`.

The only thing that worked was to cycle through the paused state by sending the `SPACE` keypresses when the video is loaded.
