### PR TITLE
fix loadfile error due to mpv changing loadfile syntax

### DIFF
--- a/reload.lua
+++ b/reload.lua
@@ -287,8 +287,8 @@ function reload(path, time_pos)
   else
     local success = mp.commandv("loadfile", path, "replace", -1, "start=+" .. time_pos)
     -- fallback to old syntax of loadfile for compatibility
-    if success ~= true then
-      msg.warn("old loadfile syntax detected. update mpv to remove this warning")
+    if success == nil then
+      msg.warn("old loadfile syntax detected. falling back to using old syntax. update mpv to remove this warning")
       mp.commandv("loadfile", path, "replace", "start=+" .. time_pos)
     end
   end

--- a/reload.lua
+++ b/reload.lua
@@ -285,7 +285,12 @@ function reload(path, time_pos)
   if time_pos == nil then
     mp.commandv("loadfile", path, "replace")
   else
-    mp.commandv("loadfile", path, "replace", "start=+" .. time_pos)
+    local success = mp.commandv("loadfile", path, "replace", -1, "start=+" .. time_pos)
+    -- fallback to old syntax of loadfile for compatibility
+    if success ~= true then
+      msg.warn("old loadfile syntax detected. update mpv to remove this warning")
+      mp.commandv("loadfile", path, "replace", "start=+" .. time_pos)
+    end
   end
 end
 


### PR DESCRIPTION
fixes https://github.com/4e6/mpv-reload/issues/19

mpv added an additional argument to loadfile in https://github.com/mpv-player/mpv/commit/c678033c1d60b48ae02fbbe4815869b9504a17f6 which caused an error

maintained compatibility with old syntax with a fallback